### PR TITLE
refactor: simplify request props

### DIFF
--- a/scripts/fix-generated-types.mjs
+++ b/scripts/fix-generated-types.mjs
@@ -168,6 +168,23 @@ content = content.replace(/export enum [^{]+\{[\s\S]*?\}/g, (block) =>
   block.replace(/= '([^']+)'/g, (_, value) => `= '${toConstantCase(value)}'`)
 );
 
+content = content.replace(
+  /export interface RequestPurchaseProps \{[\s\S]*?\}\n\n/,
+  [
+    'export type RequestPurchaseProps =',
+    '  | {',
+    '      /** Per-platform purchase request props */',
+    '      request: RequestPurchasePropsByPlatforms;',
+    "      type: 'in-app';",
+    '    }',
+    '  | {',
+    '      /** Per-platform subscription request props */',
+    '      request: RequestSubscriptionPropsByPlatforms;',
+    "      type: 'subs';",
+    '    };\n\n',
+  ].join('\n'),
+);
+
 const futureFields = new Set();
 for (const file of schemaFiles) {
   let previousWasMarker = false;

--- a/src/api.graphql
+++ b/src/api.graphql
@@ -40,7 +40,7 @@ extend type Mutation {
   Initiate a purchase flow; rely on events for final state
   """
   # Future
-  requestPurchase(params: PurchaseParams!): RequestPurchaseResult
+  requestPurchase(params: RequestPurchaseProps!): RequestPurchaseResult
   """
   Finish a transaction after validating receipts
   """

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -196,7 +196,7 @@ export interface MutationFinishTransactionArgs {
 
 
 export interface MutationRequestPurchaseArgs {
-  params: PurchaseParams;
+  params: RequestPurchaseProps;
 }
 
 
@@ -436,15 +436,6 @@ export interface PurchaseOptions {
   onlyIncludeActiveItemsIOS?: (boolean | null);
 }
 
-export interface PurchaseParams {
-  /** Per-platform purchase request props */
-  requestPurchase?: (RequestPurchasePropsByPlatforms | null);
-  /** Per-platform subscription request props */
-  requestSubscription?: (RequestSubscriptionPropsByPlatforms | null);
-  /** Explicit purchase type hint (defaults to in-app) */
-  type?: (ProductQueryType | null);
-}
-
 export type PurchaseState = 'deferred' | 'failed' | 'pending' | 'purchased' | 'restored' | 'unknown';
 
 export interface Query {
@@ -613,12 +604,17 @@ export interface RequestPurchaseIosProps {
   withOffer?: (DiscountOfferInputIOS | null);
 }
 
-export interface RequestPurchaseProps {
-  /** Android-specific purchase parameters */
-  android?: (RequestPurchaseAndroidProps | null);
-  /** iOS-specific purchase parameters */
-  ios?: (RequestPurchaseIosProps | null);
-}
+export type RequestPurchaseProps =
+  | {
+      /** Per-platform purchase request props */
+      request: RequestPurchasePropsByPlatforms;
+      type: 'in-app';
+    }
+  | {
+      /** Per-platform subscription request props */
+      request: RequestSubscriptionPropsByPlatforms;
+      type: 'subs';
+    };
 
 export interface RequestPurchasePropsByPlatforms {
   /** Android-specific purchase parameters */

--- a/src/type.graphql
+++ b/src/type.graphql
@@ -106,7 +106,7 @@ input PurchaseOptions {
 }
 
 # Parameters for requestPurchase
-input PurchaseParams {
+input RequestPurchaseProps {
   """
   Per-platform purchase request props
   """
@@ -147,17 +147,6 @@ input DeepLinkOptions {
 }
 
 # Request props (platform-specific containers)
-input RequestPurchaseProps {
-  """
-  iOS-specific purchase parameters
-  """
-  ios: RequestPurchaseIosProps
-  """
-  Android-specific purchase parameters
-  """
-  android: RequestPurchaseAndroidProps
-}
-
 input RequestPurchasePropsByPlatforms {
   """
   iOS-specific purchase parameters


### PR DESCRIPTION
## Summary
Replace `PurchaseParams` with the new `RequestPurchaseProps` union across the schema and generated bindings, exposing a consistent `{ request, type }` contract.

## Testing
- npm run generate:ts
- npm run generate:swift
- npm run generate:kotlin
- npm run generate:dart
