### PR TITLE
Add helper support for root operations

### DIFF
--- a/src/generated/Types.kt
+++ b/src/generated/Types.kt
@@ -2080,3 +2080,89 @@ public interface SubscriptionResolver {
      */
     suspend fun purchaseUpdated(): Purchase
 }
+
+// MARK: - Root Operation Helpers
+
+// MARK: - Mutation Helpers
+
+public typealias MutationAcknowledgePurchaseAndroidHandler = suspend (purchaseToken: String) -> VoidResult
+public typealias MutationBeginRefundRequestIOSHandler = suspend (sku: String) -> RefundResultIOS
+public typealias MutationClearTransactionIOSHandler = suspend () -> VoidResult
+public typealias MutationConsumePurchaseAndroidHandler = suspend (purchaseToken: String) -> VoidResult
+public typealias MutationDeepLinkToSubscriptionsHandler = suspend (options: DeepLinkOptions?) -> VoidResult
+public typealias MutationEndConnectionHandler = suspend () -> Boolean
+public typealias MutationFinishTransactionHandler = suspend (purchase: PurchaseInput, isConsumable: Boolean?) -> VoidResult
+public typealias MutationInitConnectionHandler = suspend () -> Boolean
+public typealias MutationPresentCodeRedemptionSheetIOSHandler = suspend () -> VoidResult
+public typealias MutationRequestPurchaseHandler = suspend (params: RequestPurchaseProps) -> RequestPurchaseResult?
+public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = suspend () -> PurchaseIOS
+public typealias MutationRestorePurchasesHandler = suspend () -> VoidResult
+public typealias MutationShowManageSubscriptionsIOSHandler = suspend () -> List<PurchaseIOS>
+public typealias MutationSyncIOSHandler = suspend () -> VoidResult
+public typealias MutationValidateReceiptHandler = suspend (options: ReceiptValidationProps) -> ReceiptValidationResult
+
+public data class MutationHandlers(
+    val acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidHandler? = null,
+    val beginRefundRequestIOS: MutationBeginRefundRequestIOSHandler? = null,
+    val clearTransactionIOS: MutationClearTransactionIOSHandler? = null,
+    val consumePurchaseAndroid: MutationConsumePurchaseAndroidHandler? = null,
+    val deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsHandler? = null,
+    val endConnection: MutationEndConnectionHandler? = null,
+    val finishTransaction: MutationFinishTransactionHandler? = null,
+    val initConnection: MutationInitConnectionHandler? = null,
+    val presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = null,
+    val requestPurchase: MutationRequestPurchaseHandler? = null,
+    val requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = null,
+    val restorePurchases: MutationRestorePurchasesHandler? = null,
+    val showManageSubscriptionsIOS: MutationShowManageSubscriptionsIOSHandler? = null,
+    val syncIOS: MutationSyncIOSHandler? = null,
+    val validateReceipt: MutationValidateReceiptHandler? = null
+)
+
+// MARK: - Query Helpers
+
+public typealias QueryCurrentEntitlementIOSHandler = suspend (skus: List<String>?) -> List<EntitlementIOS>
+public typealias QueryFetchProductsHandler = suspend (params: ProductRequest) -> FetchProductsResult
+public typealias QueryGetActiveSubscriptionsHandler = suspend (subscriptionIds: List<String>?) -> List<ActiveSubscription>
+public typealias QueryGetAppTransactionIOSHandler = suspend () -> AppTransaction?
+public typealias QueryGetAvailablePurchasesHandler = suspend (options: PurchaseOptions?) -> List<Purchase>
+public typealias QueryGetPendingTransactionsIOSHandler = suspend () -> List<PurchaseIOS>
+public typealias QueryGetPromotedProductIOSHandler = suspend () -> ProductIOS?
+public typealias QueryGetReceiptDataIOSHandler = suspend () -> String
+public typealias QueryGetStorefrontIOSHandler = suspend () -> String
+public typealias QueryGetTransactionJwsIOSHandler = suspend (transactionId: String) -> String
+public typealias QueryHasActiveSubscriptionsHandler = suspend (subscriptionIds: List<String>?) -> Boolean
+public typealias QueryIsEligibleForIntroOfferIOSHandler = suspend (productIds: List<String>) -> Boolean
+public typealias QueryIsTransactionVerifiedIOSHandler = suspend (transactionId: String) -> Boolean
+public typealias QueryLatestTransactionIOSHandler = suspend (sku: String) -> PurchaseIOS?
+public typealias QuerySubscriptionStatusIOSHandler = suspend (skus: List<String>?) -> List<SubscriptionStatusIOS>
+
+public data class QueryHandlers(
+    val currentEntitlementIOS: QueryCurrentEntitlementIOSHandler? = null,
+    val fetchProducts: QueryFetchProductsHandler? = null,
+    val getActiveSubscriptions: QueryGetActiveSubscriptionsHandler? = null,
+    val getAppTransactionIOS: QueryGetAppTransactionIOSHandler? = null,
+    val getAvailablePurchases: QueryGetAvailablePurchasesHandler? = null,
+    val getPendingTransactionsIOS: QueryGetPendingTransactionsIOSHandler? = null,
+    val getPromotedProductIOS: QueryGetPromotedProductIOSHandler? = null,
+    val getReceiptDataIOS: QueryGetReceiptDataIOSHandler? = null,
+    val getStorefrontIOS: QueryGetStorefrontIOSHandler? = null,
+    val getTransactionJwsIOS: QueryGetTransactionJwsIOSHandler? = null,
+    val hasActiveSubscriptions: QueryHasActiveSubscriptionsHandler? = null,
+    val isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIOSHandler? = null,
+    val isTransactionVerifiedIOS: QueryIsTransactionVerifiedIOSHandler? = null,
+    val latestTransactionIOS: QueryLatestTransactionIOSHandler? = null,
+    val subscriptionStatusIOS: QuerySubscriptionStatusIOSHandler? = null
+)
+
+// MARK: - Subscription Helpers
+
+public typealias SubscriptionPromotedProductIOSHandler = suspend () -> String
+public typealias SubscriptionPurchaseErrorHandler = suspend () -> PurchaseError
+public typealias SubscriptionPurchaseUpdatedHandler = suspend () -> Purchase
+
+public data class SubscriptionHandlers(
+    val promotedProductIOS: SubscriptionPromotedProductIOSHandler? = null,
+    val purchaseError: SubscriptionPurchaseErrorHandler? = null,
+    val purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = null
+)

--- a/src/generated/Types.swift
+++ b/src/generated/Types.swift
@@ -1001,3 +1001,167 @@ public protocol SubscriptionResolver {
     /// Fires when a purchase completes successfully or a pending purchase resolves
     func purchaseUpdated() async throws -> Purchase
 }
+
+// MARK: - Root Operation Helpers
+
+// MARK: - Mutation Helpers
+
+public typealias MutationAcknowledgePurchaseAndroidHandler = (_ purchaseToken: String) async throws -> VoidResult
+public typealias MutationBeginRefundRequestIOSHandler = (_ sku: String) async throws -> RefundResultIOS
+public typealias MutationClearTransactionIOSHandler = () async throws -> VoidResult
+public typealias MutationConsumePurchaseAndroidHandler = (_ purchaseToken: String) async throws -> VoidResult
+public typealias MutationDeepLinkToSubscriptionsHandler = (_ options: DeepLinkOptions?) async throws -> VoidResult
+public typealias MutationEndConnectionHandler = () async throws -> Bool
+public typealias MutationFinishTransactionHandler = (_ purchase: PurchaseInput, _ isConsumable: Bool?) async throws -> VoidResult
+public typealias MutationInitConnectionHandler = () async throws -> Bool
+public typealias MutationPresentCodeRedemptionSheetIOSHandler = () async throws -> VoidResult
+public typealias MutationRequestPurchaseHandler = (_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
+public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = () async throws -> PurchaseIOS
+public typealias MutationRestorePurchasesHandler = () async throws -> VoidResult
+public typealias MutationShowManageSubscriptionsIOSHandler = () async throws -> [PurchaseIOS]
+public typealias MutationSyncIOSHandler = () async throws -> VoidResult
+public typealias MutationValidateReceiptHandler = (_ options: ReceiptValidationProps) async throws -> ReceiptValidationResult
+
+public struct MutationHandlers {
+    public var acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidHandler?
+    public var beginRefundRequestIOS: MutationBeginRefundRequestIOSHandler?
+    public var clearTransactionIOS: MutationClearTransactionIOSHandler?
+    public var consumePurchaseAndroid: MutationConsumePurchaseAndroidHandler?
+    public var deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsHandler?
+    public var endConnection: MutationEndConnectionHandler?
+    public var finishTransaction: MutationFinishTransactionHandler?
+    public var initConnection: MutationInitConnectionHandler?
+    public var presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler?
+    public var requestPurchase: MutationRequestPurchaseHandler?
+    public var requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler?
+    public var restorePurchases: MutationRestorePurchasesHandler?
+    public var showManageSubscriptionsIOS: MutationShowManageSubscriptionsIOSHandler?
+    public var syncIOS: MutationSyncIOSHandler?
+    public var validateReceipt: MutationValidateReceiptHandler?
+
+    public init(
+        acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidHandler? = nil,
+        beginRefundRequestIOS: MutationBeginRefundRequestIOSHandler? = nil,
+        clearTransactionIOS: MutationClearTransactionIOSHandler? = nil,
+        consumePurchaseAndroid: MutationConsumePurchaseAndroidHandler? = nil,
+        deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsHandler? = nil,
+        endConnection: MutationEndConnectionHandler? = nil,
+        finishTransaction: MutationFinishTransactionHandler? = nil,
+        initConnection: MutationInitConnectionHandler? = nil,
+        presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = nil,
+        requestPurchase: MutationRequestPurchaseHandler? = nil,
+        requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = nil,
+        restorePurchases: MutationRestorePurchasesHandler? = nil,
+        showManageSubscriptionsIOS: MutationShowManageSubscriptionsIOSHandler? = nil,
+        syncIOS: MutationSyncIOSHandler? = nil,
+        validateReceipt: MutationValidateReceiptHandler? = nil
+    ) {
+        self.acknowledgePurchaseAndroid = acknowledgePurchaseAndroid
+        self.beginRefundRequestIOS = beginRefundRequestIOS
+        self.clearTransactionIOS = clearTransactionIOS
+        self.consumePurchaseAndroid = consumePurchaseAndroid
+        self.deepLinkToSubscriptions = deepLinkToSubscriptions
+        self.endConnection = endConnection
+        self.finishTransaction = finishTransaction
+        self.initConnection = initConnection
+        self.presentCodeRedemptionSheetIOS = presentCodeRedemptionSheetIOS
+        self.requestPurchase = requestPurchase
+        self.requestPurchaseOnPromotedProductIOS = requestPurchaseOnPromotedProductIOS
+        self.restorePurchases = restorePurchases
+        self.showManageSubscriptionsIOS = showManageSubscriptionsIOS
+        self.syncIOS = syncIOS
+        self.validateReceipt = validateReceipt
+    }
+}
+
+// MARK: - Query Helpers
+
+public typealias QueryCurrentEntitlementIOSHandler = (_ skus: [String]?) async throws -> [EntitlementIOS]
+public typealias QueryFetchProductsHandler = (_ params: ProductRequest) async throws -> FetchProductsResult
+public typealias QueryGetActiveSubscriptionsHandler = (_ subscriptionIds: [String]?) async throws -> [ActiveSubscription]
+public typealias QueryGetAppTransactionIOSHandler = () async throws -> AppTransaction?
+public typealias QueryGetAvailablePurchasesHandler = (_ options: PurchaseOptions?) async throws -> [Purchase]
+public typealias QueryGetPendingTransactionsIOSHandler = () async throws -> [PurchaseIOS]
+public typealias QueryGetPromotedProductIOSHandler = () async throws -> ProductIOS?
+public typealias QueryGetReceiptDataIOSHandler = () async throws -> String
+public typealias QueryGetStorefrontIOSHandler = () async throws -> String
+public typealias QueryGetTransactionJwsIOSHandler = (_ transactionId: String) async throws -> String
+public typealias QueryHasActiveSubscriptionsHandler = (_ subscriptionIds: [String]?) async throws -> Bool
+public typealias QueryIsEligibleForIntroOfferIOSHandler = (_ productIds: [String]) async throws -> Bool
+public typealias QueryIsTransactionVerifiedIOSHandler = (_ transactionId: String) async throws -> Bool
+public typealias QueryLatestTransactionIOSHandler = (_ sku: String) async throws -> PurchaseIOS?
+public typealias QuerySubscriptionStatusIOSHandler = (_ skus: [String]?) async throws -> [SubscriptionStatusIOS]
+
+public struct QueryHandlers {
+    public var currentEntitlementIOS: QueryCurrentEntitlementIOSHandler?
+    public var fetchProducts: QueryFetchProductsHandler?
+    public var getActiveSubscriptions: QueryGetActiveSubscriptionsHandler?
+    public var getAppTransactionIOS: QueryGetAppTransactionIOSHandler?
+    public var getAvailablePurchases: QueryGetAvailablePurchasesHandler?
+    public var getPendingTransactionsIOS: QueryGetPendingTransactionsIOSHandler?
+    public var getPromotedProductIOS: QueryGetPromotedProductIOSHandler?
+    public var getReceiptDataIOS: QueryGetReceiptDataIOSHandler?
+    public var getStorefrontIOS: QueryGetStorefrontIOSHandler?
+    public var getTransactionJwsIOS: QueryGetTransactionJwsIOSHandler?
+    public var hasActiveSubscriptions: QueryHasActiveSubscriptionsHandler?
+    public var isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIOSHandler?
+    public var isTransactionVerifiedIOS: QueryIsTransactionVerifiedIOSHandler?
+    public var latestTransactionIOS: QueryLatestTransactionIOSHandler?
+    public var subscriptionStatusIOS: QuerySubscriptionStatusIOSHandler?
+
+    public init(
+        currentEntitlementIOS: QueryCurrentEntitlementIOSHandler? = nil,
+        fetchProducts: QueryFetchProductsHandler? = nil,
+        getActiveSubscriptions: QueryGetActiveSubscriptionsHandler? = nil,
+        getAppTransactionIOS: QueryGetAppTransactionIOSHandler? = nil,
+        getAvailablePurchases: QueryGetAvailablePurchasesHandler? = nil,
+        getPendingTransactionsIOS: QueryGetPendingTransactionsIOSHandler? = nil,
+        getPromotedProductIOS: QueryGetPromotedProductIOSHandler? = nil,
+        getReceiptDataIOS: QueryGetReceiptDataIOSHandler? = nil,
+        getStorefrontIOS: QueryGetStorefrontIOSHandler? = nil,
+        getTransactionJwsIOS: QueryGetTransactionJwsIOSHandler? = nil,
+        hasActiveSubscriptions: QueryHasActiveSubscriptionsHandler? = nil,
+        isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIOSHandler? = nil,
+        isTransactionVerifiedIOS: QueryIsTransactionVerifiedIOSHandler? = nil,
+        latestTransactionIOS: QueryLatestTransactionIOSHandler? = nil,
+        subscriptionStatusIOS: QuerySubscriptionStatusIOSHandler? = nil
+    ) {
+        self.currentEntitlementIOS = currentEntitlementIOS
+        self.fetchProducts = fetchProducts
+        self.getActiveSubscriptions = getActiveSubscriptions
+        self.getAppTransactionIOS = getAppTransactionIOS
+        self.getAvailablePurchases = getAvailablePurchases
+        self.getPendingTransactionsIOS = getPendingTransactionsIOS
+        self.getPromotedProductIOS = getPromotedProductIOS
+        self.getReceiptDataIOS = getReceiptDataIOS
+        self.getStorefrontIOS = getStorefrontIOS
+        self.getTransactionJwsIOS = getTransactionJwsIOS
+        self.hasActiveSubscriptions = hasActiveSubscriptions
+        self.isEligibleForIntroOfferIOS = isEligibleForIntroOfferIOS
+        self.isTransactionVerifiedIOS = isTransactionVerifiedIOS
+        self.latestTransactionIOS = latestTransactionIOS
+        self.subscriptionStatusIOS = subscriptionStatusIOS
+    }
+}
+
+// MARK: - Subscription Helpers
+
+public typealias SubscriptionPromotedProductIOSHandler = () async throws -> String
+public typealias SubscriptionPurchaseErrorHandler = () async throws -> PurchaseError
+public typealias SubscriptionPurchaseUpdatedHandler = () async throws -> Purchase
+
+public struct SubscriptionHandlers {
+    public var promotedProductIOS: SubscriptionPromotedProductIOSHandler?
+    public var purchaseError: SubscriptionPurchaseErrorHandler?
+    public var purchaseUpdated: SubscriptionPurchaseUpdatedHandler?
+
+    public init(
+        promotedProductIOS: SubscriptionPromotedProductIOSHandler? = nil,
+        purchaseError: SubscriptionPurchaseErrorHandler? = nil,
+        purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = nil
+    ) {
+        self.promotedProductIOS = promotedProductIOS
+        self.purchaseError = purchaseError
+        self.purchaseUpdated = purchaseUpdated
+    }
+}

--- a/src/generated/types.dart
+++ b/src/generated/types.dart
@@ -2707,3 +2707,166 @@ abstract class SubscriptionResolver {
   /// Fires when a purchase completes successfully or a pending purchase resolves
   Future<Purchase> purchaseUpdated();
 }
+
+// MARK: - Root Operation Helpers
+
+// MARK: - Mutation Helpers
+
+typedef MutationAcknowledgePurchaseAndroidHandler = Future<VoidResult> Function({
+  required String purchaseToken,
+});
+typedef MutationBeginRefundRequestIOSHandler = Future<RefundResultIOS> Function({
+  required String sku,
+});
+typedef MutationClearTransactionIOSHandler = Future<VoidResult> Function();
+typedef MutationConsumePurchaseAndroidHandler = Future<VoidResult> Function({
+  required String purchaseToken,
+});
+typedef MutationDeepLinkToSubscriptionsHandler = Future<VoidResult> Function({
+  DeepLinkOptions? options,
+});
+typedef MutationEndConnectionHandler = Future<bool> Function();
+typedef MutationFinishTransactionHandler = Future<VoidResult> Function({
+  required PurchaseInput purchase,
+  bool? isConsumable,
+});
+typedef MutationInitConnectionHandler = Future<bool> Function();
+typedef MutationPresentCodeRedemptionSheetIOSHandler = Future<VoidResult> Function();
+typedef MutationRequestPurchaseHandler = Future<RequestPurchaseResult?> Function({
+  required RequestPurchaseProps params,
+});
+typedef MutationRequestPurchaseOnPromotedProductIOSHandler = Future<PurchaseIOS> Function();
+typedef MutationRestorePurchasesHandler = Future<VoidResult> Function();
+typedef MutationShowManageSubscriptionsIOSHandler = Future<List<PurchaseIOS>> Function();
+typedef MutationSyncIOSHandler = Future<VoidResult> Function();
+typedef MutationValidateReceiptHandler = Future<ReceiptValidationResult> Function({
+  required ReceiptValidationProps options,
+});
+
+class MutationHandlers {
+  const MutationHandlers({
+    this.acknowledgePurchaseAndroid,
+    this.beginRefundRequestIOS,
+    this.clearTransactionIOS,
+    this.consumePurchaseAndroid,
+    this.deepLinkToSubscriptions,
+    this.endConnection,
+    this.finishTransaction,
+    this.initConnection,
+    this.presentCodeRedemptionSheetIOS,
+    this.requestPurchase,
+    this.requestPurchaseOnPromotedProductIOS,
+    this.restorePurchases,
+    this.showManageSubscriptionsIOS,
+    this.syncIOS,
+    this.validateReceipt,
+  });
+
+  final MutationAcknowledgePurchaseAndroidHandler? acknowledgePurchaseAndroid;
+  final MutationBeginRefundRequestIOSHandler? beginRefundRequestIOS;
+  final MutationClearTransactionIOSHandler? clearTransactionIOS;
+  final MutationConsumePurchaseAndroidHandler? consumePurchaseAndroid;
+  final MutationDeepLinkToSubscriptionsHandler? deepLinkToSubscriptions;
+  final MutationEndConnectionHandler? endConnection;
+  final MutationFinishTransactionHandler? finishTransaction;
+  final MutationInitConnectionHandler? initConnection;
+  final MutationPresentCodeRedemptionSheetIOSHandler? presentCodeRedemptionSheetIOS;
+  final MutationRequestPurchaseHandler? requestPurchase;
+  final MutationRequestPurchaseOnPromotedProductIOSHandler? requestPurchaseOnPromotedProductIOS;
+  final MutationRestorePurchasesHandler? restorePurchases;
+  final MutationShowManageSubscriptionsIOSHandler? showManageSubscriptionsIOS;
+  final MutationSyncIOSHandler? syncIOS;
+  final MutationValidateReceiptHandler? validateReceipt;
+}
+
+// MARK: - Query Helpers
+
+typedef QueryCurrentEntitlementIOSHandler = Future<List<EntitlementIOS>> Function({
+  List<String>? skus,
+});
+typedef QueryFetchProductsHandler = Future<FetchProductsResult> Function({
+  required ProductRequest params,
+});
+typedef QueryGetActiveSubscriptionsHandler = Future<List<ActiveSubscription>> Function({
+  List<String>? subscriptionIds,
+});
+typedef QueryGetAppTransactionIOSHandler = Future<AppTransaction?> Function();
+typedef QueryGetAvailablePurchasesHandler = Future<List<Purchase>> Function({
+  PurchaseOptions? options,
+});
+typedef QueryGetPendingTransactionsIOSHandler = Future<List<PurchaseIOS>> Function();
+typedef QueryGetPromotedProductIOSHandler = Future<ProductIOS?> Function();
+typedef QueryGetReceiptDataIOSHandler = Future<String> Function();
+typedef QueryGetStorefrontIOSHandler = Future<String> Function();
+typedef QueryGetTransactionJwsIOSHandler = Future<String> Function({
+  required String transactionId,
+});
+typedef QueryHasActiveSubscriptionsHandler = Future<bool> Function({
+  List<String>? subscriptionIds,
+});
+typedef QueryIsEligibleForIntroOfferIOSHandler = Future<bool> Function({
+  required List<String> productIds,
+});
+typedef QueryIsTransactionVerifiedIOSHandler = Future<bool> Function({
+  required String transactionId,
+});
+typedef QueryLatestTransactionIOSHandler = Future<PurchaseIOS?> Function({
+  required String sku,
+});
+typedef QuerySubscriptionStatusIOSHandler = Future<List<SubscriptionStatusIOS>> Function({
+  List<String>? skus,
+});
+
+class QueryHandlers {
+  const QueryHandlers({
+    this.currentEntitlementIOS,
+    this.fetchProducts,
+    this.getActiveSubscriptions,
+    this.getAppTransactionIOS,
+    this.getAvailablePurchases,
+    this.getPendingTransactionsIOS,
+    this.getPromotedProductIOS,
+    this.getReceiptDataIOS,
+    this.getStorefrontIOS,
+    this.getTransactionJwsIOS,
+    this.hasActiveSubscriptions,
+    this.isEligibleForIntroOfferIOS,
+    this.isTransactionVerifiedIOS,
+    this.latestTransactionIOS,
+    this.subscriptionStatusIOS,
+  });
+
+  final QueryCurrentEntitlementIOSHandler? currentEntitlementIOS;
+  final QueryFetchProductsHandler? fetchProducts;
+  final QueryGetActiveSubscriptionsHandler? getActiveSubscriptions;
+  final QueryGetAppTransactionIOSHandler? getAppTransactionIOS;
+  final QueryGetAvailablePurchasesHandler? getAvailablePurchases;
+  final QueryGetPendingTransactionsIOSHandler? getPendingTransactionsIOS;
+  final QueryGetPromotedProductIOSHandler? getPromotedProductIOS;
+  final QueryGetReceiptDataIOSHandler? getReceiptDataIOS;
+  final QueryGetStorefrontIOSHandler? getStorefrontIOS;
+  final QueryGetTransactionJwsIOSHandler? getTransactionJwsIOS;
+  final QueryHasActiveSubscriptionsHandler? hasActiveSubscriptions;
+  final QueryIsEligibleForIntroOfferIOSHandler? isEligibleForIntroOfferIOS;
+  final QueryIsTransactionVerifiedIOSHandler? isTransactionVerifiedIOS;
+  final QueryLatestTransactionIOSHandler? latestTransactionIOS;
+  final QuerySubscriptionStatusIOSHandler? subscriptionStatusIOS;
+}
+
+// MARK: - Subscription Helpers
+
+typedef SubscriptionPromotedProductIOSHandler = Future<String> Function();
+typedef SubscriptionPurchaseErrorHandler = Future<PurchaseError> Function();
+typedef SubscriptionPurchaseUpdatedHandler = Future<Purchase> Function();
+
+class SubscriptionHandlers {
+  const SubscriptionHandlers({
+    this.promotedProductIOS,
+    this.purchaseError,
+    this.purchaseUpdated,
+  });
+
+  final SubscriptionPromotedProductIOSHandler? promotedProductIOS;
+  final SubscriptionPurchaseErrorHandler? purchaseError;
+  final SubscriptionPurchaseUpdatedHandler? purchaseUpdated;
+}

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -703,3 +703,77 @@ export interface SubscriptionStatusIOS {
 export interface VoidResult {
   success: boolean;
 }
+// -- Query helper types (auto-generated)
+export type QueryArgsMap = {
+  currentEntitlementIOS: QueryCurrentEntitlementIosArgs;
+  fetchProducts: QueryFetchProductsArgs;
+  getActiveSubscriptions: QueryGetActiveSubscriptionsArgs;
+  getAppTransactionIOS: never;
+  getAvailablePurchases: QueryGetAvailablePurchasesArgs;
+  getPendingTransactionsIOS: never;
+  getPromotedProductIOS: never;
+  getReceiptDataIOS: never;
+  getStorefrontIOS: never;
+  getTransactionJwsIOS: QueryGetTransactionJwsIosArgs;
+  hasActiveSubscriptions: QueryHasActiveSubscriptionsArgs;
+  isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIosArgs;
+  isTransactionVerifiedIOS: QueryIsTransactionVerifiedIosArgs;
+  latestTransactionIOS: QueryLatestTransactionIosArgs;
+  subscriptionStatusIOS: QuerySubscriptionStatusIosArgs;
+};
+
+export type QueryField<K extends keyof Query> =
+  QueryArgsMap[K] extends never
+    ? () => NonNullable<Query[K]>
+    : (args: QueryArgsMap[K]) => NonNullable<Query[K]>;
+
+export type QueryFieldMap = {
+  [K in keyof Query]?: QueryField<K>;
+};
+// -- End query helper types
+
+// -- Mutation helper types (auto-generated)
+export type MutationArgsMap = {
+  acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidArgs;
+  beginRefundRequestIOS: MutationBeginRefundRequestIosArgs;
+  clearTransactionIOS: never;
+  consumePurchaseAndroid: MutationConsumePurchaseAndroidArgs;
+  deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsArgs;
+  endConnection: never;
+  finishTransaction: MutationFinishTransactionArgs;
+  initConnection: never;
+  presentCodeRedemptionSheetIOS: never;
+  requestPurchase: MutationRequestPurchaseArgs;
+  requestPurchaseOnPromotedProductIOS: never;
+  restorePurchases: never;
+  showManageSubscriptionsIOS: never;
+  syncIOS: never;
+  validateReceipt: MutationValidateReceiptArgs;
+};
+
+export type MutationField<K extends keyof Mutation> =
+  MutationArgsMap[K] extends never
+    ? () => NonNullable<Mutation[K]>
+    : (args: MutationArgsMap[K]) => NonNullable<Mutation[K]>;
+
+export type MutationFieldMap = {
+  [K in keyof Mutation]?: MutationField<K>;
+};
+// -- End mutation helper types
+
+// -- Subscription helper types (auto-generated)
+export type SubscriptionArgsMap = {
+  promotedProductIOS: never;
+  purchaseError: never;
+  purchaseUpdated: never;
+};
+
+export type SubscriptionField<K extends keyof Subscription> =
+  SubscriptionArgsMap[K] extends never
+    ? () => NonNullable<Subscription[K]>
+    : (args: SubscriptionArgsMap[K]) => NonNullable<Subscription[K]>;
+
+export type SubscriptionFieldMap = {
+  [K in keyof Subscription]?: SubscriptionField<K>;
+};
+// -- End subscription helper types


### PR DESCRIPTION
Add typed helper exports for Query, Mutation, and Subscription so generated TypeScript, Dart, Kotlin, and Swift clients enforce argument signatures.

Regenerate emitted files to expose the helpers immediately.