### PR TITLE
feat: enhanced external purchase apis

### DIFF
--- a/src/api-ios.graphql
+++ b/src/api-ios.graphql
@@ -12,6 +12,11 @@ extend type Query {
   # Future
   getPromotedProductIOS: ProductIOS
   """
+  Check if external purchase notice sheet can be presented (iOS 18.2+)
+  """
+  # Future
+  canPresentExternalPurchaseNoticeIOS: Boolean!
+  """
   Retrieve all pending transactions in the StoreKit queue
   """
   # Future
@@ -94,6 +99,11 @@ extend type Mutation {
   """
   # Future
   presentCodeRedemptionSheetIOS: Boolean!
+  """
+  Present external purchase notice sheet (iOS 18.2+)
+  """
+  # Future
+  presentExternalPurchaseNoticeSheetIOS: ExternalPurchaseNoticeResultIOS!
   """
   Present external purchase custom link with StoreKit UI (iOS 18.2+)
   """

--- a/src/api-ios.graphql
+++ b/src/api-ios.graphql
@@ -94,4 +94,9 @@ extend type Mutation {
   """
   # Future
   presentCodeRedemptionSheetIOS: Boolean!
+  """
+  Present external purchase custom link with StoreKit UI (iOS 18.2+)
+  """
+  # Future
+  presentExternalPurchaseLinkIOS(url: String!): ExternalPurchaseLinkResultIOS!
 }

--- a/src/event.graphql
+++ b/src/event.graphql
@@ -13,4 +13,9 @@ extend type Subscription {
   Fires when the App Store surfaces a promoted product (iOS only)
   """
   promotedProductIOS: String!
+  """
+  Fires when a user selects alternative billing in the User Choice Billing dialog (Android only)
+  Only triggered when the user selects alternative billing instead of Google Play billing
+  """
+  userChoiceBillingAndroid: UserChoiceBillingDetails!
 }

--- a/src/generated/Types.kt
+++ b/src/generated/Types.kt
@@ -189,6 +189,34 @@ public enum class ErrorCode(val rawValue: String) {
     fun toJson(): String = rawValue
 }
 
+/**
+ * User actions on external purchase notice sheet (iOS 18.2+)
+ */
+public enum class ExternalPurchaseNoticeAction(val rawValue: String) {
+    /**
+     * User chose to continue to external purchase
+     */
+    Continue("continue"),
+    /**
+     * User dismissed the notice sheet
+     */
+    Dismissed("dismissed")
+
+    companion object {
+        fun fromJson(value: String): ExternalPurchaseNoticeAction = when (value) {
+            "continue" -> ExternalPurchaseNoticeAction.Continue
+            "CONTINUE" -> ExternalPurchaseNoticeAction.Continue
+            "Continue" -> ExternalPurchaseNoticeAction.Continue
+            "dismissed" -> ExternalPurchaseNoticeAction.Dismissed
+            "DISMISSED" -> ExternalPurchaseNoticeAction.Dismissed
+            "Dismissed" -> ExternalPurchaseNoticeAction.Dismissed
+            else -> throw IllegalArgumentException("Unknown ExternalPurchaseNoticeAction value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
 public enum class IapEvent(val rawValue: String) {
     PurchaseUpdated("purchase-updated"),
     PurchaseError("purchase-error"),
@@ -702,6 +730,36 @@ public data class ExternalPurchaseLinkResultIOS(
         "__typename" to "ExternalPurchaseLinkResultIOS",
         "error" to error,
         "success" to success,
+    )
+}
+
+/**
+ * Result of presenting external purchase notice sheet (iOS 18.2+)
+ */
+public data class ExternalPurchaseNoticeResultIOS(
+    /**
+     * Optional error message if the presentation failed
+     */
+    val error: String? = null,
+    /**
+     * Notice result indicating user action
+     */
+    val result: ExternalPurchaseNoticeAction
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ExternalPurchaseNoticeResultIOS {
+            return ExternalPurchaseNoticeResultIOS(
+                error = json["error"] as String?,
+                result = ExternalPurchaseNoticeAction.fromJson(json["result"] as String),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ExternalPurchaseNoticeResultIOS",
+        "error" to error,
+        "result" to result.toJson(),
     )
 }
 
@@ -1563,6 +1621,37 @@ public data class SubscriptionStatusIOS(
     )
 }
 
+/**
+ * User Choice Billing event details (Android)
+ * Fired when a user selects alternative billing in the User Choice Billing dialog
+ */
+public data class UserChoiceBillingDetails(
+    /**
+     * Token that must be reported to Google Play within 24 hours
+     */
+    val externalTransactionToken: String,
+    /**
+     * List of product IDs selected by the user
+     */
+    val products: List<String>
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): UserChoiceBillingDetails {
+            return UserChoiceBillingDetails(
+                externalTransactionToken = json["externalTransactionToken"] as String,
+                products = (json["products"] as List<*>).map { it as String },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "UserChoiceBillingDetails",
+        "externalTransactionToken" to externalTransactionToken,
+        "products" to products.map { it },
+    )
+}
+
 public typealias VoidResult = Unit
 
 // MARK: - Input Objects
@@ -1826,10 +1915,6 @@ public data class RequestPurchaseIosProps(
      */
     val appAccountToken: String? = null,
     /**
-     * External purchase URL for alternative billing (iOS)
-     */
-    val externalPurchaseUrl: String? = null,
-    /**
      * Purchase quantity
      */
     val quantity: Int? = null,
@@ -1847,7 +1932,6 @@ public data class RequestPurchaseIosProps(
             return RequestPurchaseIosProps(
                 andDangerouslyFinishTransactionAutomatically = json["andDangerouslyFinishTransactionAutomatically"] as Boolean?,
                 appAccountToken = json["appAccountToken"] as String?,
-                externalPurchaseUrl = json["externalPurchaseUrl"] as String?,
                 quantity = (json["quantity"] as Number?)?.toInt(),
                 sku = json["sku"] as String,
                 withOffer = (json["withOffer"] as Map<String, Any?>?)?.let { DiscountOfferInputIOS.fromJson(it) },
@@ -1858,7 +1942,6 @@ public data class RequestPurchaseIosProps(
     fun toJson(): Map<String, Any?> = mapOf(
         "andDangerouslyFinishTransactionAutomatically" to andDangerouslyFinishTransactionAutomatically,
         "appAccountToken" to appAccountToken,
-        "externalPurchaseUrl" to externalPurchaseUrl,
         "quantity" to quantity,
         "sku" to sku,
         "withOffer" to withOffer?.toJson(),
@@ -2001,10 +2084,6 @@ public data class RequestSubscriptionAndroidProps(
 public data class RequestSubscriptionIosProps(
     val andDangerouslyFinishTransactionAutomatically: Boolean? = null,
     val appAccountToken: String? = null,
-    /**
-     * External purchase URL for alternative billing (iOS)
-     */
-    val externalPurchaseUrl: String? = null,
     val quantity: Int? = null,
     val sku: String,
     val withOffer: DiscountOfferInputIOS? = null
@@ -2014,7 +2093,6 @@ public data class RequestSubscriptionIosProps(
             return RequestSubscriptionIosProps(
                 andDangerouslyFinishTransactionAutomatically = json["andDangerouslyFinishTransactionAutomatically"] as Boolean?,
                 appAccountToken = json["appAccountToken"] as String?,
-                externalPurchaseUrl = json["externalPurchaseUrl"] as String?,
                 quantity = (json["quantity"] as Number?)?.toInt(),
                 sku = json["sku"] as String,
                 withOffer = (json["withOffer"] as Map<String, Any?>?)?.let { DiscountOfferInputIOS.fromJson(it) },
@@ -2025,7 +2103,6 @@ public data class RequestSubscriptionIosProps(
     fun toJson(): Map<String, Any?> = mapOf(
         "andDangerouslyFinishTransactionAutomatically" to andDangerouslyFinishTransactionAutomatically,
         "appAccountToken" to appAccountToken,
-        "externalPurchaseUrl" to externalPurchaseUrl,
         "quantity" to quantity,
         "sku" to sku,
         "withOffer" to withOffer?.toJson(),
@@ -2180,6 +2257,10 @@ public interface MutationResolver {
      */
     suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS
     /**
+     * Present external purchase notice sheet (iOS 18.2+)
+     */
+    suspend fun presentExternalPurchaseNoticeSheetIOS(): ExternalPurchaseNoticeResultIOS
+    /**
      * Initiate a purchase flow; rely on events for final state
      */
     suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
@@ -2218,6 +2299,10 @@ public interface MutationResolver {
  * GraphQL root query operations.
  */
 public interface QueryResolver {
+    /**
+     * Check if external purchase notice sheet can be presented (iOS 18.2+)
+     */
+    suspend fun canPresentExternalPurchaseNoticeIOS(): Boolean
     /**
      * Get current StoreKit 2 entitlements (iOS 15+)
      */
@@ -2304,6 +2389,11 @@ public interface SubscriptionResolver {
      * Fires when a purchase completes successfully or a pending purchase resolves
      */
     suspend fun purchaseUpdated(): Purchase
+    /**
+     * Fires when a user selects alternative billing in the User Choice Billing dialog (Android only)
+     * Only triggered when the user selects alternative billing instead of Google Play billing
+     */
+    suspend fun userChoiceBillingAndroid(): UserChoiceBillingDetails
 }
 
 // MARK: - Root Operation Helpers
@@ -2322,6 +2412,7 @@ public typealias MutationFinishTransactionHandler = suspend (purchase: PurchaseI
 public typealias MutationInitConnectionHandler = suspend (config: InitConnectionConfig?) -> Boolean
 public typealias MutationPresentCodeRedemptionSheetIOSHandler = suspend () -> Boolean
 public typealias MutationPresentExternalPurchaseLinkIOSHandler = suspend (url: String) -> ExternalPurchaseLinkResultIOS
+public typealias MutationPresentExternalPurchaseNoticeSheetIOSHandler = suspend () -> ExternalPurchaseNoticeResultIOS
 public typealias MutationRequestPurchaseHandler = suspend (params: RequestPurchaseProps) -> RequestPurchaseResult?
 public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = suspend () -> Boolean
 public typealias MutationRestorePurchasesHandler = suspend () -> Unit
@@ -2343,6 +2434,7 @@ public data class MutationHandlers(
     val initConnection: MutationInitConnectionHandler? = null,
     val presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = null,
     val presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler? = null,
+    val presentExternalPurchaseNoticeSheetIOS: MutationPresentExternalPurchaseNoticeSheetIOSHandler? = null,
     val requestPurchase: MutationRequestPurchaseHandler? = null,
     val requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = null,
     val restorePurchases: MutationRestorePurchasesHandler? = null,
@@ -2354,6 +2446,7 @@ public data class MutationHandlers(
 
 // MARK: - Query Helpers
 
+public typealias QueryCanPresentExternalPurchaseNoticeIOSHandler = suspend () -> Boolean
 public typealias QueryCurrentEntitlementIOSHandler = suspend (sku: String) -> PurchaseIOS?
 public typealias QueryFetchProductsHandler = suspend (params: ProductRequest) -> FetchProductsResult
 public typealias QueryGetActiveSubscriptionsHandler = suspend (subscriptionIds: List<String>?) -> List<ActiveSubscription>
@@ -2373,6 +2466,7 @@ public typealias QuerySubscriptionStatusIOSHandler = suspend (sku: String) -> Li
 public typealias QueryValidateReceiptIOSHandler = suspend (options: ReceiptValidationProps) -> ReceiptValidationResultIOS
 
 public data class QueryHandlers(
+    val canPresentExternalPurchaseNoticeIOS: QueryCanPresentExternalPurchaseNoticeIOSHandler? = null,
     val currentEntitlementIOS: QueryCurrentEntitlementIOSHandler? = null,
     val fetchProducts: QueryFetchProductsHandler? = null,
     val getActiveSubscriptions: QueryGetActiveSubscriptionsHandler? = null,
@@ -2397,9 +2491,11 @@ public data class QueryHandlers(
 public typealias SubscriptionPromotedProductIOSHandler = suspend () -> String
 public typealias SubscriptionPurchaseErrorHandler = suspend () -> PurchaseError
 public typealias SubscriptionPurchaseUpdatedHandler = suspend () -> Purchase
+public typealias SubscriptionUserChoiceBillingAndroidHandler = suspend () -> UserChoiceBillingDetails
 
 public data class SubscriptionHandlers(
     val promotedProductIOS: SubscriptionPromotedProductIOSHandler? = null,
     val purchaseError: SubscriptionPurchaseErrorHandler? = null,
-    val purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = null
+    val purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = null,
+    val userChoiceBillingAndroid: SubscriptionUserChoiceBillingAndroidHandler? = null
 )

--- a/src/generated/Types.kt
+++ b/src/generated/Types.kt
@@ -675,6 +675,36 @@ public data class EntitlementIOS(
     )
 }
 
+/**
+ * Result of presenting an external purchase link (iOS 18.2+)
+ */
+public data class ExternalPurchaseLinkResultIOS(
+    /**
+     * Optional error message if the presentation failed
+     */
+    val error: String? = null,
+    /**
+     * Whether the user completed the external purchase flow
+     */
+    val success: Boolean
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ExternalPurchaseLinkResultIOS {
+            return ExternalPurchaseLinkResultIOS(
+                error = json["error"] as String?,
+                success = json["success"] as Boolean,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ExternalPurchaseLinkResultIOS",
+        "error" to error,
+        "success" to success,
+    )
+}
+
 public sealed interface FetchProductsResult
 
 public data class FetchProductsResultProducts(val value: List<Product>?) : FetchProductsResult
@@ -2146,6 +2176,10 @@ public interface MutationResolver {
      */
     suspend fun presentCodeRedemptionSheetIOS(): Boolean
     /**
+     * Present external purchase custom link with StoreKit UI (iOS 18.2+)
+     */
+    suspend fun presentExternalPurchaseLinkIOS(url: String): ExternalPurchaseLinkResultIOS
+    /**
      * Initiate a purchase flow; rely on events for final state
      */
     suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
@@ -2287,6 +2321,7 @@ public typealias MutationEndConnectionHandler = suspend () -> Boolean
 public typealias MutationFinishTransactionHandler = suspend (purchase: PurchaseInput, isConsumable: Boolean?) -> Unit
 public typealias MutationInitConnectionHandler = suspend (config: InitConnectionConfig?) -> Boolean
 public typealias MutationPresentCodeRedemptionSheetIOSHandler = suspend () -> Boolean
+public typealias MutationPresentExternalPurchaseLinkIOSHandler = suspend (url: String) -> ExternalPurchaseLinkResultIOS
 public typealias MutationRequestPurchaseHandler = suspend (params: RequestPurchaseProps) -> RequestPurchaseResult?
 public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = suspend () -> Boolean
 public typealias MutationRestorePurchasesHandler = suspend () -> Unit
@@ -2307,6 +2342,7 @@ public data class MutationHandlers(
     val finishTransaction: MutationFinishTransactionHandler? = null,
     val initConnection: MutationInitConnectionHandler? = null,
     val presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = null,
+    val presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler? = null,
     val requestPurchase: MutationRequestPurchaseHandler? = null,
     val requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = null,
     val restorePurchases: MutationRestorePurchasesHandler? = null,

--- a/src/generated/Types.swift
+++ b/src/generated/Types.swift
@@ -217,6 +217,14 @@ public struct EntitlementIOS: Codable {
     public var transactionId: String
 }
 
+/// Result of presenting an external purchase link (iOS 18.2+)
+public struct ExternalPurchaseLinkResultIOS: Codable {
+    /// Optional error message if the presentation failed
+    public var error: String?
+    /// Whether the user completed the external purchase flow
+    public var success: Bool
+}
+
 public enum FetchProductsResult {
     case products([Product]?)
     case subscriptions([ProductSubscription]?)
@@ -1155,6 +1163,8 @@ public protocol MutationResolver {
     func initConnection(_ config: InitConnectionConfig?) async throws -> Bool
     /// Present the App Store code redemption sheet
     func presentCodeRedemptionSheetIOS() async throws -> Bool
+    /// Present external purchase custom link with StoreKit UI (iOS 18.2+)
+    func presentExternalPurchaseLinkIOS(_ url: String) async throws -> ExternalPurchaseLinkResultIOS
     /// Initiate a purchase flow; rely on events for final state
     func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
     /// Purchase the promoted product surfaced by the App Store
@@ -1239,6 +1249,7 @@ public typealias MutationEndConnectionHandler = () async throws -> Bool
 public typealias MutationFinishTransactionHandler = (_ purchase: PurchaseInput, _ isConsumable: Bool?) async throws -> Void
 public typealias MutationInitConnectionHandler = (_ config: InitConnectionConfig?) async throws -> Bool
 public typealias MutationPresentCodeRedemptionSheetIOSHandler = () async throws -> Bool
+public typealias MutationPresentExternalPurchaseLinkIOSHandler = (_ url: String) async throws -> ExternalPurchaseLinkResultIOS
 public typealias MutationRequestPurchaseHandler = (_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
 public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = () async throws -> Bool
 public typealias MutationRestorePurchasesHandler = () async throws -> Void
@@ -1259,6 +1270,7 @@ public struct MutationHandlers {
     public var finishTransaction: MutationFinishTransactionHandler?
     public var initConnection: MutationInitConnectionHandler?
     public var presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler?
+    public var presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler?
     public var requestPurchase: MutationRequestPurchaseHandler?
     public var requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler?
     public var restorePurchases: MutationRestorePurchasesHandler?
@@ -1279,6 +1291,7 @@ public struct MutationHandlers {
         finishTransaction: MutationFinishTransactionHandler? = nil,
         initConnection: MutationInitConnectionHandler? = nil,
         presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = nil,
+        presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler? = nil,
         requestPurchase: MutationRequestPurchaseHandler? = nil,
         requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = nil,
         restorePurchases: MutationRestorePurchasesHandler? = nil,
@@ -1298,6 +1311,7 @@ public struct MutationHandlers {
         self.finishTransaction = finishTransaction
         self.initConnection = initConnection
         self.presentCodeRedemptionSheetIOS = presentCodeRedemptionSheetIOS
+        self.presentExternalPurchaseLinkIOS = presentExternalPurchaseLinkIOS
         self.requestPurchase = requestPurchase
         self.requestPurchaseOnPromotedProductIOS = requestPurchaseOnPromotedProductIOS
         self.restorePurchases = restorePurchases

--- a/src/generated/Types.swift
+++ b/src/generated/Types.swift
@@ -57,6 +57,14 @@ public enum ErrorCode: String, Codable, CaseIterable {
     case emptySkuList = "empty-sku-list"
 }
 
+/// User actions on external purchase notice sheet (iOS 18.2+)
+public enum ExternalPurchaseNoticeAction: String, Codable, CaseIterable {
+    /// User chose to continue to external purchase
+    case `continue` = "continue"
+    /// User dismissed the notice sheet
+    case dismissed = "dismissed"
+}
+
 public enum IapEvent: String, Codable, CaseIterable {
     case purchaseUpdated = "purchase-updated"
     case purchaseError = "purchase-error"
@@ -223,6 +231,14 @@ public struct ExternalPurchaseLinkResultIOS: Codable {
     public var error: String?
     /// Whether the user completed the external purchase flow
     public var success: Bool
+}
+
+/// Result of presenting external purchase notice sheet (iOS 18.2+)
+public struct ExternalPurchaseNoticeResultIOS: Codable {
+    /// Optional error message if the presentation failed
+    public var error: String?
+    /// Notice result indicating user action
+    public var result: ExternalPurchaseNoticeAction
 }
 
 public enum FetchProductsResult {
@@ -477,6 +493,15 @@ public struct SubscriptionStatusIOS: Codable {
     public var state: String
 }
 
+/// User Choice Billing event details (Android)
+/// Fired when a user selects alternative billing in the User Choice Billing dialog
+public struct UserChoiceBillingDetails: Codable {
+    /// Token that must be reported to Google Play within 24 hours
+    public var externalTransactionToken: String
+    /// List of product IDs selected by the user
+    public var products: [String]
+}
+
 public typealias VoidResult = Void
 
 // MARK: - Input Objects
@@ -643,8 +668,6 @@ public struct RequestPurchaseIosProps: Codable {
     public var andDangerouslyFinishTransactionAutomatically: Bool?
     /// App account token for user tracking
     public var appAccountToken: String?
-    /// External purchase URL for alternative billing (iOS)
-    public var externalPurchaseUrl: String?
     /// Purchase quantity
     public var quantity: Int?
     /// Product SKU
@@ -655,14 +678,12 @@ public struct RequestPurchaseIosProps: Codable {
     public init(
         andDangerouslyFinishTransactionAutomatically: Bool? = nil,
         appAccountToken: String? = nil,
-        externalPurchaseUrl: String? = nil,
         quantity: Int? = nil,
         sku: String,
         withOffer: DiscountOfferInputIOS? = nil
     ) {
         self.andDangerouslyFinishTransactionAutomatically = andDangerouslyFinishTransactionAutomatically
         self.appAccountToken = appAccountToken
-        self.externalPurchaseUrl = externalPurchaseUrl
         self.quantity = quantity
         self.sku = sku
         self.withOffer = withOffer
@@ -792,8 +813,6 @@ public struct RequestSubscriptionAndroidProps: Codable {
 public struct RequestSubscriptionIosProps: Codable {
     public var andDangerouslyFinishTransactionAutomatically: Bool?
     public var appAccountToken: String?
-    /// External purchase URL for alternative billing (iOS)
-    public var externalPurchaseUrl: String?
     public var quantity: Int?
     public var sku: String
     public var withOffer: DiscountOfferInputIOS?
@@ -801,14 +820,12 @@ public struct RequestSubscriptionIosProps: Codable {
     public init(
         andDangerouslyFinishTransactionAutomatically: Bool? = nil,
         appAccountToken: String? = nil,
-        externalPurchaseUrl: String? = nil,
         quantity: Int? = nil,
         sku: String,
         withOffer: DiscountOfferInputIOS? = nil
     ) {
         self.andDangerouslyFinishTransactionAutomatically = andDangerouslyFinishTransactionAutomatically
         self.appAccountToken = appAccountToken
-        self.externalPurchaseUrl = externalPurchaseUrl
         self.quantity = quantity
         self.sku = sku
         self.withOffer = withOffer
@@ -1165,6 +1182,8 @@ public protocol MutationResolver {
     func presentCodeRedemptionSheetIOS() async throws -> Bool
     /// Present external purchase custom link with StoreKit UI (iOS 18.2+)
     func presentExternalPurchaseLinkIOS(_ url: String) async throws -> ExternalPurchaseLinkResultIOS
+    /// Present external purchase notice sheet (iOS 18.2+)
+    func presentExternalPurchaseNoticeSheetIOS() async throws -> ExternalPurchaseNoticeResultIOS
     /// Initiate a purchase flow; rely on events for final state
     func requestPurchase(_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
     /// Purchase the promoted product surfaced by the App Store
@@ -1188,6 +1207,8 @@ public protocol MutationResolver {
 
 /// GraphQL root query operations.
 public protocol QueryResolver {
+    /// Check if external purchase notice sheet can be presented (iOS 18.2+)
+    func canPresentExternalPurchaseNoticeIOS() async throws -> Bool
     /// Get current StoreKit 2 entitlements (iOS 15+)
     func currentEntitlementIOS(_ sku: String) async throws -> PurchaseIOS?
     /// Retrieve products or subscriptions from the store
@@ -1232,6 +1253,9 @@ public protocol SubscriptionResolver {
     func purchaseError() async throws -> PurchaseError
     /// Fires when a purchase completes successfully or a pending purchase resolves
     func purchaseUpdated() async throws -> Purchase
+    /// Fires when a user selects alternative billing in the User Choice Billing dialog (Android only)
+    /// Only triggered when the user selects alternative billing instead of Google Play billing
+    func userChoiceBillingAndroid() async throws -> UserChoiceBillingDetails
 }
 
 // MARK: - Root Operation Helpers
@@ -1250,6 +1274,7 @@ public typealias MutationFinishTransactionHandler = (_ purchase: PurchaseInput, 
 public typealias MutationInitConnectionHandler = (_ config: InitConnectionConfig?) async throws -> Bool
 public typealias MutationPresentCodeRedemptionSheetIOSHandler = () async throws -> Bool
 public typealias MutationPresentExternalPurchaseLinkIOSHandler = (_ url: String) async throws -> ExternalPurchaseLinkResultIOS
+public typealias MutationPresentExternalPurchaseNoticeSheetIOSHandler = () async throws -> ExternalPurchaseNoticeResultIOS
 public typealias MutationRequestPurchaseHandler = (_ params: RequestPurchaseProps) async throws -> RequestPurchaseResult?
 public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = () async throws -> Bool
 public typealias MutationRestorePurchasesHandler = () async throws -> Void
@@ -1271,6 +1296,7 @@ public struct MutationHandlers {
     public var initConnection: MutationInitConnectionHandler?
     public var presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler?
     public var presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler?
+    public var presentExternalPurchaseNoticeSheetIOS: MutationPresentExternalPurchaseNoticeSheetIOSHandler?
     public var requestPurchase: MutationRequestPurchaseHandler?
     public var requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler?
     public var restorePurchases: MutationRestorePurchasesHandler?
@@ -1292,6 +1318,7 @@ public struct MutationHandlers {
         initConnection: MutationInitConnectionHandler? = nil,
         presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = nil,
         presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIOSHandler? = nil,
+        presentExternalPurchaseNoticeSheetIOS: MutationPresentExternalPurchaseNoticeSheetIOSHandler? = nil,
         requestPurchase: MutationRequestPurchaseHandler? = nil,
         requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = nil,
         restorePurchases: MutationRestorePurchasesHandler? = nil,
@@ -1312,6 +1339,7 @@ public struct MutationHandlers {
         self.initConnection = initConnection
         self.presentCodeRedemptionSheetIOS = presentCodeRedemptionSheetIOS
         self.presentExternalPurchaseLinkIOS = presentExternalPurchaseLinkIOS
+        self.presentExternalPurchaseNoticeSheetIOS = presentExternalPurchaseNoticeSheetIOS
         self.requestPurchase = requestPurchase
         self.requestPurchaseOnPromotedProductIOS = requestPurchaseOnPromotedProductIOS
         self.restorePurchases = restorePurchases
@@ -1324,6 +1352,7 @@ public struct MutationHandlers {
 
 // MARK: - Query Helpers
 
+public typealias QueryCanPresentExternalPurchaseNoticeIOSHandler = () async throws -> Bool
 public typealias QueryCurrentEntitlementIOSHandler = (_ sku: String) async throws -> PurchaseIOS?
 public typealias QueryFetchProductsHandler = (_ params: ProductRequest) async throws -> FetchProductsResult
 public typealias QueryGetActiveSubscriptionsHandler = (_ subscriptionIds: [String]?) async throws -> [ActiveSubscription]
@@ -1343,6 +1372,7 @@ public typealias QuerySubscriptionStatusIOSHandler = (_ sku: String) async throw
 public typealias QueryValidateReceiptIOSHandler = (_ options: ReceiptValidationProps) async throws -> ReceiptValidationResultIOS
 
 public struct QueryHandlers {
+    public var canPresentExternalPurchaseNoticeIOS: QueryCanPresentExternalPurchaseNoticeIOSHandler?
     public var currentEntitlementIOS: QueryCurrentEntitlementIOSHandler?
     public var fetchProducts: QueryFetchProductsHandler?
     public var getActiveSubscriptions: QueryGetActiveSubscriptionsHandler?
@@ -1362,6 +1392,7 @@ public struct QueryHandlers {
     public var validateReceiptIOS: QueryValidateReceiptIOSHandler?
 
     public init(
+        canPresentExternalPurchaseNoticeIOS: QueryCanPresentExternalPurchaseNoticeIOSHandler? = nil,
         currentEntitlementIOS: QueryCurrentEntitlementIOSHandler? = nil,
         fetchProducts: QueryFetchProductsHandler? = nil,
         getActiveSubscriptions: QueryGetActiveSubscriptionsHandler? = nil,
@@ -1380,6 +1411,7 @@ public struct QueryHandlers {
         subscriptionStatusIOS: QuerySubscriptionStatusIOSHandler? = nil,
         validateReceiptIOS: QueryValidateReceiptIOSHandler? = nil
     ) {
+        self.canPresentExternalPurchaseNoticeIOS = canPresentExternalPurchaseNoticeIOS
         self.currentEntitlementIOS = currentEntitlementIOS
         self.fetchProducts = fetchProducts
         self.getActiveSubscriptions = getActiveSubscriptions
@@ -1405,19 +1437,23 @@ public struct QueryHandlers {
 public typealias SubscriptionPromotedProductIOSHandler = () async throws -> String
 public typealias SubscriptionPurchaseErrorHandler = () async throws -> PurchaseError
 public typealias SubscriptionPurchaseUpdatedHandler = () async throws -> Purchase
+public typealias SubscriptionUserChoiceBillingAndroidHandler = () async throws -> UserChoiceBillingDetails
 
 public struct SubscriptionHandlers {
     public var promotedProductIOS: SubscriptionPromotedProductIOSHandler?
     public var purchaseError: SubscriptionPurchaseErrorHandler?
     public var purchaseUpdated: SubscriptionPurchaseUpdatedHandler?
+    public var userChoiceBillingAndroid: SubscriptionUserChoiceBillingAndroidHandler?
 
     public init(
         promotedProductIOS: SubscriptionPromotedProductIOSHandler? = nil,
         purchaseError: SubscriptionPurchaseErrorHandler? = nil,
-        purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = nil
+        purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = nil,
+        userChoiceBillingAndroid: SubscriptionUserChoiceBillingAndroidHandler? = nil
     ) {
         self.promotedProductIOS = promotedProductIOS
         self.purchaseError = purchaseError
         self.purchaseUpdated = purchaseUpdated
+        self.userChoiceBillingAndroid = userChoiceBillingAndroid
     }
 }

--- a/src/generated/types.dart
+++ b/src/generated/types.dart
@@ -814,6 +814,36 @@ class EntitlementIOS {
   }
 }
 
+/// Result of presenting an external purchase link (iOS 18.2+)
+class ExternalPurchaseLinkResultIOS {
+  const ExternalPurchaseLinkResultIOS({
+    /// Optional error message if the presentation failed
+    this.error,
+    /// Whether the user completed the external purchase flow
+    required this.success,
+  });
+
+  /// Optional error message if the presentation failed
+  final String? error;
+  /// Whether the user completed the external purchase flow
+  final bool success;
+
+  factory ExternalPurchaseLinkResultIOS.fromJson(Map<String, dynamic> json) {
+    return ExternalPurchaseLinkResultIOS(
+      error: json['error'] as String?,
+      success: json['success'] as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      '__typename': 'ExternalPurchaseLinkResultIOS',
+      'error': error,
+      'success': success,
+    };
+  }
+}
+
 abstract class FetchProductsResult {
   const FetchProductsResult();
 }
@@ -2653,6 +2683,8 @@ abstract class MutationResolver {
   });
   /// Present the App Store code redemption sheet
   Future<bool> presentCodeRedemptionSheetIOS();
+  /// Present external purchase custom link with StoreKit UI (iOS 18.2+)
+  Future<ExternalPurchaseLinkResultIOS> presentExternalPurchaseLinkIOS(String url);
   /// Initiate a purchase flow; rely on events for final state
   Future<RequestPurchaseResult?> requestPurchase(RequestPurchaseProps params);
   /// Purchase the promoted product surfaced by the App Store
@@ -2757,6 +2789,7 @@ typedef MutationInitConnectionHandler = Future<bool> Function({
   AlternativeBillingModeAndroid? alternativeBillingModeAndroid,
 });
 typedef MutationPresentCodeRedemptionSheetIOSHandler = Future<bool> Function();
+typedef MutationPresentExternalPurchaseLinkIOSHandler = Future<ExternalPurchaseLinkResultIOS> Function(String url);
 typedef MutationRequestPurchaseHandler = Future<RequestPurchaseResult?> Function(RequestPurchaseProps params);
 typedef MutationRequestPurchaseOnPromotedProductIOSHandler = Future<bool> Function();
 typedef MutationRestorePurchasesHandler = Future<void> Function();
@@ -2781,6 +2814,7 @@ class MutationHandlers {
     this.finishTransaction,
     this.initConnection,
     this.presentCodeRedemptionSheetIOS,
+    this.presentExternalPurchaseLinkIOS,
     this.requestPurchase,
     this.requestPurchaseOnPromotedProductIOS,
     this.restorePurchases,
@@ -2801,6 +2835,7 @@ class MutationHandlers {
   final MutationFinishTransactionHandler? finishTransaction;
   final MutationInitConnectionHandler? initConnection;
   final MutationPresentCodeRedemptionSheetIOSHandler? presentCodeRedemptionSheetIOS;
+  final MutationPresentExternalPurchaseLinkIOSHandler? presentExternalPurchaseLinkIOS;
   final MutationRequestPurchaseHandler? requestPurchase;
   final MutationRequestPurchaseOnPromotedProductIOSHandler? requestPurchaseOnPromotedProductIOS;
   final MutationRestorePurchasesHandler? restorePurchases;

--- a/src/generated/types.dart
+++ b/src/generated/types.dart
@@ -226,6 +226,33 @@ enum ErrorCode {
   String toJson() => value;
 }
 
+/// User actions on external purchase notice sheet (iOS 18.2+)
+enum ExternalPurchaseNoticeAction {
+  /// User chose to continue to external purchase
+  Continue('continue'),
+  /// User dismissed the notice sheet
+  Dismissed('dismissed');
+
+  const ExternalPurchaseNoticeAction(this.value);
+  final String value;
+
+  factory ExternalPurchaseNoticeAction.fromJson(String value) {
+    switch (value) {
+      case 'continue':
+      case 'CONTINUE':
+      case 'Continue':
+        return ExternalPurchaseNoticeAction.Continue;
+      case 'dismissed':
+      case 'DISMISSED':
+      case 'Dismissed':
+        return ExternalPurchaseNoticeAction.Dismissed;
+    }
+    throw ArgumentError('Unknown ExternalPurchaseNoticeAction value: $value');
+  }
+
+  String toJson() => value;
+}
+
 enum IapEvent {
   PurchaseUpdated('purchase-updated'),
   PurchaseError('purchase-error'),
@@ -840,6 +867,36 @@ class ExternalPurchaseLinkResultIOS {
       '__typename': 'ExternalPurchaseLinkResultIOS',
       'error': error,
       'success': success,
+    };
+  }
+}
+
+/// Result of presenting external purchase notice sheet (iOS 18.2+)
+class ExternalPurchaseNoticeResultIOS {
+  const ExternalPurchaseNoticeResultIOS({
+    /// Optional error message if the presentation failed
+    this.error,
+    /// Notice result indicating user action
+    required this.result,
+  });
+
+  /// Optional error message if the presentation failed
+  final String? error;
+  /// Notice result indicating user action
+  final ExternalPurchaseNoticeAction result;
+
+  factory ExternalPurchaseNoticeResultIOS.fromJson(Map<String, dynamic> json) {
+    return ExternalPurchaseNoticeResultIOS(
+      error: json['error'] as String?,
+      result: ExternalPurchaseNoticeAction.fromJson(json['result'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      '__typename': 'ExternalPurchaseNoticeResultIOS',
+      'error': error,
+      'result': result.toJson(),
     };
   }
 }
@@ -1948,6 +2005,37 @@ class SubscriptionStatusIOS {
   }
 }
 
+/// User Choice Billing event details (Android)
+/// Fired when a user selects alternative billing in the User Choice Billing dialog
+class UserChoiceBillingDetails {
+  const UserChoiceBillingDetails({
+    /// Token that must be reported to Google Play within 24 hours
+    required this.externalTransactionToken,
+    /// List of product IDs selected by the user
+    required this.products,
+  });
+
+  /// Token that must be reported to Google Play within 24 hours
+  final String externalTransactionToken;
+  /// List of product IDs selected by the user
+  final List<String> products;
+
+  factory UserChoiceBillingDetails.fromJson(Map<String, dynamic> json) {
+    return UserChoiceBillingDetails(
+      externalTransactionToken: json['externalTransactionToken'] as String,
+      products: (json['products'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      '__typename': 'UserChoiceBillingDetails',
+      'externalTransactionToken': externalTransactionToken,
+      'products': products.map((e) => e).toList(),
+    };
+  }
+}
+
 typedef VoidResult = void;
 
 // MARK: - Input Objects
@@ -2239,8 +2327,6 @@ class RequestPurchaseIosProps {
     this.andDangerouslyFinishTransactionAutomatically,
     /// App account token for user tracking
     this.appAccountToken,
-    /// External purchase URL for alternative billing (iOS)
-    this.externalPurchaseUrl,
     /// Purchase quantity
     this.quantity,
     /// Product SKU
@@ -2253,8 +2339,6 @@ class RequestPurchaseIosProps {
   final bool? andDangerouslyFinishTransactionAutomatically;
   /// App account token for user tracking
   final String? appAccountToken;
-  /// External purchase URL for alternative billing (iOS)
-  final String? externalPurchaseUrl;
   /// Purchase quantity
   final int? quantity;
   /// Product SKU
@@ -2266,7 +2350,6 @@ class RequestPurchaseIosProps {
     return RequestPurchaseIosProps(
       andDangerouslyFinishTransactionAutomatically: json['andDangerouslyFinishTransactionAutomatically'] as bool?,
       appAccountToken: json['appAccountToken'] as String?,
-      externalPurchaseUrl: json['externalPurchaseUrl'] as String?,
       quantity: json['quantity'] as int?,
       sku: json['sku'] as String,
       withOffer: json['withOffer'] != null ? DiscountOfferInputIOS.fromJson(json['withOffer'] as Map<String, dynamic>) : null,
@@ -2277,7 +2360,6 @@ class RequestPurchaseIosProps {
     return {
       'andDangerouslyFinishTransactionAutomatically': andDangerouslyFinishTransactionAutomatically,
       'appAccountToken': appAccountToken,
-      'externalPurchaseUrl': externalPurchaseUrl,
       'quantity': quantity,
       'sku': sku,
       'withOffer': withOffer?.toJson(),
@@ -2435,8 +2517,6 @@ class RequestSubscriptionIosProps {
   const RequestSubscriptionIosProps({
     this.andDangerouslyFinishTransactionAutomatically,
     this.appAccountToken,
-    /// External purchase URL for alternative billing (iOS)
-    this.externalPurchaseUrl,
     this.quantity,
     required this.sku,
     this.withOffer,
@@ -2444,8 +2524,6 @@ class RequestSubscriptionIosProps {
 
   final bool? andDangerouslyFinishTransactionAutomatically;
   final String? appAccountToken;
-  /// External purchase URL for alternative billing (iOS)
-  final String? externalPurchaseUrl;
   final int? quantity;
   final String sku;
   final DiscountOfferInputIOS? withOffer;
@@ -2454,7 +2532,6 @@ class RequestSubscriptionIosProps {
     return RequestSubscriptionIosProps(
       andDangerouslyFinishTransactionAutomatically: json['andDangerouslyFinishTransactionAutomatically'] as bool?,
       appAccountToken: json['appAccountToken'] as String?,
-      externalPurchaseUrl: json['externalPurchaseUrl'] as String?,
       quantity: json['quantity'] as int?,
       sku: json['sku'] as String,
       withOffer: json['withOffer'] != null ? DiscountOfferInputIOS.fromJson(json['withOffer'] as Map<String, dynamic>) : null,
@@ -2465,7 +2542,6 @@ class RequestSubscriptionIosProps {
     return {
       'andDangerouslyFinishTransactionAutomatically': andDangerouslyFinishTransactionAutomatically,
       'appAccountToken': appAccountToken,
-      'externalPurchaseUrl': externalPurchaseUrl,
       'quantity': quantity,
       'sku': sku,
       'withOffer': withOffer?.toJson(),
@@ -2685,6 +2761,8 @@ abstract class MutationResolver {
   Future<bool> presentCodeRedemptionSheetIOS();
   /// Present external purchase custom link with StoreKit UI (iOS 18.2+)
   Future<ExternalPurchaseLinkResultIOS> presentExternalPurchaseLinkIOS(String url);
+  /// Present external purchase notice sheet (iOS 18.2+)
+  Future<ExternalPurchaseNoticeResultIOS> presentExternalPurchaseNoticeSheetIOS();
   /// Initiate a purchase flow; rely on events for final state
   Future<RequestPurchaseResult?> requestPurchase(RequestPurchaseProps params);
   /// Purchase the promoted product surfaced by the App Store
@@ -2711,6 +2789,8 @@ abstract class MutationResolver {
 
 /// GraphQL root query operations.
 abstract class QueryResolver {
+  /// Check if external purchase notice sheet can be presented (iOS 18.2+)
+  Future<bool> canPresentExternalPurchaseNoticeIOS();
   /// Get current StoreKit 2 entitlements (iOS 15+)
   Future<PurchaseIOS?> currentEntitlementIOS(String sku);
   /// Retrieve products or subscriptions from the store
@@ -2764,6 +2844,9 @@ abstract class SubscriptionResolver {
   Future<PurchaseError> purchaseError();
   /// Fires when a purchase completes successfully or a pending purchase resolves
   Future<Purchase> purchaseUpdated();
+  /// Fires when a user selects alternative billing in the User Choice Billing dialog (Android only)
+  /// Only triggered when the user selects alternative billing instead of Google Play billing
+  Future<UserChoiceBillingDetails> userChoiceBillingAndroid();
 }
 
 // MARK: - Root Operation Helpers
@@ -2790,6 +2873,7 @@ typedef MutationInitConnectionHandler = Future<bool> Function({
 });
 typedef MutationPresentCodeRedemptionSheetIOSHandler = Future<bool> Function();
 typedef MutationPresentExternalPurchaseLinkIOSHandler = Future<ExternalPurchaseLinkResultIOS> Function(String url);
+typedef MutationPresentExternalPurchaseNoticeSheetIOSHandler = Future<ExternalPurchaseNoticeResultIOS> Function();
 typedef MutationRequestPurchaseHandler = Future<RequestPurchaseResult?> Function(RequestPurchaseProps params);
 typedef MutationRequestPurchaseOnPromotedProductIOSHandler = Future<bool> Function();
 typedef MutationRestorePurchasesHandler = Future<void> Function();
@@ -2815,6 +2899,7 @@ class MutationHandlers {
     this.initConnection,
     this.presentCodeRedemptionSheetIOS,
     this.presentExternalPurchaseLinkIOS,
+    this.presentExternalPurchaseNoticeSheetIOS,
     this.requestPurchase,
     this.requestPurchaseOnPromotedProductIOS,
     this.restorePurchases,
@@ -2836,6 +2921,7 @@ class MutationHandlers {
   final MutationInitConnectionHandler? initConnection;
   final MutationPresentCodeRedemptionSheetIOSHandler? presentCodeRedemptionSheetIOS;
   final MutationPresentExternalPurchaseLinkIOSHandler? presentExternalPurchaseLinkIOS;
+  final MutationPresentExternalPurchaseNoticeSheetIOSHandler? presentExternalPurchaseNoticeSheetIOS;
   final MutationRequestPurchaseHandler? requestPurchase;
   final MutationRequestPurchaseOnPromotedProductIOSHandler? requestPurchaseOnPromotedProductIOS;
   final MutationRestorePurchasesHandler? restorePurchases;
@@ -2847,6 +2933,7 @@ class MutationHandlers {
 
 // MARK: - Query Helpers
 
+typedef QueryCanPresentExternalPurchaseNoticeIOSHandler = Future<bool> Function();
 typedef QueryCurrentEntitlementIOSHandler = Future<PurchaseIOS?> Function(String sku);
 typedef QueryFetchProductsHandler = Future<FetchProductsResult> Function({
   required List<String> skus,
@@ -2876,6 +2963,7 @@ typedef QueryValidateReceiptIOSHandler = Future<ReceiptValidationResultIOS> Func
 
 class QueryHandlers {
   const QueryHandlers({
+    this.canPresentExternalPurchaseNoticeIOS,
     this.currentEntitlementIOS,
     this.fetchProducts,
     this.getActiveSubscriptions,
@@ -2895,6 +2983,7 @@ class QueryHandlers {
     this.validateReceiptIOS,
   });
 
+  final QueryCanPresentExternalPurchaseNoticeIOSHandler? canPresentExternalPurchaseNoticeIOS;
   final QueryCurrentEntitlementIOSHandler? currentEntitlementIOS;
   final QueryFetchProductsHandler? fetchProducts;
   final QueryGetActiveSubscriptionsHandler? getActiveSubscriptions;
@@ -2919,15 +3008,18 @@ class QueryHandlers {
 typedef SubscriptionPromotedProductIOSHandler = Future<String> Function();
 typedef SubscriptionPurchaseErrorHandler = Future<PurchaseError> Function();
 typedef SubscriptionPurchaseUpdatedHandler = Future<Purchase> Function();
+typedef SubscriptionUserChoiceBillingAndroidHandler = Future<UserChoiceBillingDetails> Function();
 
 class SubscriptionHandlers {
   const SubscriptionHandlers({
     this.promotedProductIOS,
     this.purchaseError,
     this.purchaseUpdated,
+    this.userChoiceBillingAndroid,
   });
 
   final SubscriptionPromotedProductIOSHandler? promotedProductIOS;
   final SubscriptionPurchaseErrorHandler? purchaseError;
   final SubscriptionPurchaseUpdatedHandler? purchaseUpdated;
+  final SubscriptionUserChoiceBillingAndroidHandler? userChoiceBillingAndroid;
 }

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -142,6 +142,14 @@ export enum ErrorCode {
   UserError = 'user-error'
 }
 
+/** Result of presenting an external purchase link (iOS 18.2+) */
+export interface ExternalPurchaseLinkResultIOS {
+  /** Optional error message if the presentation failed */
+  error?: (string | null);
+  /** Whether the user completed the external purchase flow */
+  success: boolean;
+}
+
 export type FetchProductsResult = Product[] | ProductSubscription[] | null;
 
 export type IapEvent = 'purchase-updated' | 'purchase-error' | 'promoted-product-ios';
@@ -194,6 +202,8 @@ export interface Mutation {
   initConnection: Promise<boolean>;
   /** Present the App Store code redemption sheet */
   presentCodeRedemptionSheetIOS: Promise<boolean>;
+  /** Present external purchase custom link with StoreKit UI (iOS 18.2+) */
+  presentExternalPurchaseLinkIOS: Promise<ExternalPurchaseLinkResultIOS>;
   /** Initiate a purchase flow; rely on events for final state */
   requestPurchase?: Promise<(Purchase | Purchase[] | null)>;
   /** Purchase the promoted product surfaced by the App Store */
@@ -234,6 +244,8 @@ export interface MutationFinishTransactionArgs {
 
 
 export type MutationInitConnectionArgs = (InitConnectionConfig | null) | undefined;
+
+export type MutationPresentExternalPurchaseLinkIosArgs = string;
 
 export type MutationRequestPurchaseArgs =
   | {
@@ -786,6 +798,7 @@ export type MutationArgsMap = {
   finishTransaction: MutationFinishTransactionArgs;
   initConnection: MutationInitConnectionArgs;
   presentCodeRedemptionSheetIOS: never;
+  presentExternalPurchaseLinkIOS: MutationPresentExternalPurchaseLinkIosArgs;
   requestPurchase: MutationRequestPurchaseArgs;
   requestPurchaseOnPromotedProductIOS: never;
   restorePurchases: never;

--- a/src/type-android.graphql
+++ b/src/type-android.graphql
@@ -205,3 +205,19 @@ enum AlternativeBillingModeAndroid {
   ALTERNATIVE_ONLY
 }
 
+# User Choice Billing
+"""
+User Choice Billing event details (Android)
+Fired when a user selects alternative billing in the User Choice Billing dialog
+"""
+type UserChoiceBillingDetails {
+  """
+  Token that must be reported to Google Play within 24 hours
+  """
+  externalTransactionToken: String!
+  """
+  List of product IDs selected by the user
+  """
+  products: [String!]!
+}
+

--- a/src/type-ios.graphql
+++ b/src/type-ios.graphql
@@ -312,3 +312,17 @@ type AppTransaction {
   appTransactionId: String
   originalPlatform: String
 }
+
+"""
+Result of presenting an external purchase link (iOS 18.2+)
+"""
+type ExternalPurchaseLinkResultIOS {
+  """
+  Whether the user completed the external purchase flow
+  """
+  success: Boolean!
+  """
+  Optional error message if the presentation failed
+  """
+  error: String
+}

--- a/src/type-ios.graphql
+++ b/src/type-ios.graphql
@@ -187,10 +187,6 @@ input RequestPurchaseIosProps {
   Discount offer to apply
   """
   withOffer: DiscountOfferInputIOS
-  """
-  External purchase URL for alternative billing (iOS)
-  """
-  externalPurchaseUrl: String
 }
 
 # iOS uses the same props for subscriptions
@@ -200,10 +196,6 @@ input RequestSubscriptionIosProps {
   appAccountToken: String
   quantity: Int
   withOffer: DiscountOfferInputIOS
-  """
-  External purchase URL for alternative billing (iOS)
-  """
-  externalPurchaseUrl: String
 }
 
 # iOS Discount Offer (input)
@@ -311,6 +303,34 @@ type AppTransaction {
   preorderDate: Float
   appTransactionId: String
   originalPlatform: String
+}
+
+"""
+Result of presenting external purchase notice sheet (iOS 18.2+)
+"""
+type ExternalPurchaseNoticeResultIOS {
+  """
+  Notice result indicating user action
+  """
+  result: ExternalPurchaseNoticeAction!
+  """
+  Optional error message if the presentation failed
+  """
+  error: String
+}
+
+"""
+User actions on external purchase notice sheet (iOS 18.2+)
+"""
+enum ExternalPurchaseNoticeAction {
+  """
+  User chose to continue to external purchase
+  """
+  Continue
+  """
+  User dismissed the notice sheet
+  """
+  Dismissed
 }
 
 """


### PR DESCRIPTION
- Add iOS External Purchase Notice Sheet (iOS 18.2+)
  - canPresentExternalPurchaseNoticeIOS query
  - presentExternalPurchaseNoticeSheetIOS mutation
  - ExternalPurchaseNoticeResultIOS and ExternalPurchaseNoticeAction types
- Add Android User Choice Billing event
  - userChoiceBillingAndroid subscription listener
  - UserChoiceBillingDetails type with external transaction token
- Remove deprecated externalPurchaseUrl parameter from iOS purchase/subscription props